### PR TITLE
CI/CD maintenance

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,15 +53,3 @@ jobs:
             -f docker-compose-ci.yml \
             run docs \
             npm run docs:build
-      - name: Publish
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: appleboy/scp-action@v0.1.1
-        with:
-          host: ${{ secrets.HOST }}
-          fingerprint: ${{ secrets.FINGERPRINT }}
-          username: ${{ secrets.USERNAME }}
-          key: ${{ secrets.SSH_PRIVATE_KEY }}
-          passphrase: ${{ secrets.SSH_PRIVATE_KEY_PASSPHRASE }}
-          port: ${{ secrets.PORT }}
-          source: "site/*"
-          target: ${{ secrets.PATH }}

--- a/Dockerfile-ci
+++ b/Dockerfile-ci
@@ -84,10 +84,9 @@ RUN curl -OfsSL \
         bin/
 
 # Upgrade pip:
-# WORKAROUND Pin setuptools until https://github.com/byrnereese/mkdocs-minify-plugin/issues/15 is fixed:
 RUN pip3 install --upgrade --no-cache-dir \
         pip \
-        setuptools==57.5.0 \
+        setuptools \
         wheel \
     ; \
     apt-get remove -y \

--- a/Dockerfile-ci
+++ b/Dockerfile-ci
@@ -1,4 +1,5 @@
-FROM ubuntu:rolling
+# FROM ubuntu:rolling
+FROM ubuntu:20.10
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/Dockerfile-ci
+++ b/Dockerfile-ci
@@ -49,7 +49,7 @@ RUN curl -fsSL https://raw.githubusercontent.com/tj/n/master/bin/n \
     npm install -g npm@latest
 
 # hadolint:
-ARG HADOLINT_VERSION=2.6.0
+ARG HADOLINT_VERSION=2.7.0
 RUN curl -fsSL \
         "https://github.com/hadolint/hadolint/releases/download/v${HADOLINT_VERSION}/hadolint-Linux-x86_64" \
         -o /usr/local/bin/hadolint; \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,68 @@
+pipeline {
+    agent any
+    environment {
+        USER_ID = """${sh(
+                returnStdout: true,
+                script: 'id -u'
+            ).trim()}"""
+        GROUP_ID = """${sh(
+                returnStdout: true,
+                script: 'id -g'
+            ).trim()}"""
+    }
+    stages {
+        stage('Pre-build') {
+            steps {
+                bitbucketStatusNotify(buildState: 'INPROGRESS')
+                sh("docker-compose \
+                    -f docker-compose-ci.yml \
+                    build \
+                    --pull \
+                    --build-arg USER_ID=${env.USER_ID} \
+                    --build-arg GROUP_ID=${env.GROUP_ID} \
+                ")
+            }
+        }
+        stage('Install') {
+            stage('Install NPM dependencies') {
+                steps {
+                    sh('docker-compose -f docker-compose-ci.yml run docs npm install')
+                }
+            }
+        }
+        stage('Build') {
+            steps {
+                sh('docker-compose -f docker-compose-ci.yml run docs npm run docs:build')
+            }
+        }
+        stage('Deploy') {
+            steps {
+                sh('scp -r site/* docs.i-doit.cloud:/var/www/docs')
+            }
+        }
+    }
+    post {
+        always {
+            deleteDir()
+        }
+        failure {
+            bitbucketStatusNotify(buildState: 'FAILED', commitId: "${env.GIT_COMMIT}")
+            slackSend(channel: '#jenkins', color: 'danger', message: "FAILED - ${env.BUILD_URL}")
+        }
+        unstable {
+            bitbucketStatusNotify(buildState: 'SUCCESSFUL', commitId: "${env.GIT_COMMIT}")
+            slackSend(channel: '#jenkins', color: 'warning', message: "UNSTABLE - ${env.BUILD_URL}")
+        }
+        success {
+            bitbucketStatusNotify(buildState: 'SUCCESSFUL', commitId: "${env.GIT_COMMIT}")
+        }
+        aborted {
+            bitbucketStatusNotify(buildState: 'FAILED', commitId: "${env.GIT_COMMIT}")
+            slackSend(channel: '#jenkins', color: 'danger', message: "ABORTED - ${env.BUILD_URL}")
+        }
+        fixed {
+            bitbucketStatusNotify(buildState: 'SUCCESSFUL', commitId: "${env.GIT_COMMIT}")
+            slackSend(channel: '#jenkins', color: 'good', message: "BACK TO NORMAL - ${env.BUILD_URL}")
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -34,9 +34,10 @@
         "markdown-spellcheck": "git+https://github.com/lukeapage/node-markdown-spellcheck.git",
         "npm-run-all": "^4.1",
         "rapidoc": "^9",
-        "remark-cli": "^9.0",
-        "remark-frontmatter": "^3",
-        "remark-lint": "^8.0",
+        "remark-cli": "^10.0",
+        "remark-frontmatter": "^4",
+        "remark-gfm": "^2",
+        "remark-lint": "^9.0",
         "remark-lint-match-punctuation": "^0.2.0",
         "remark-lint-no-dead-urls": "^1.1.0",
         "remark-lint-no-empty-sections": "^4.0.0",
@@ -44,9 +45,9 @@
         "remark-lint-no-repeat-punctuation": "^0.1.3",
         "remark-lint-no-trailing-spaces": "^2.0.1",
         "remark-lint-write-good": "^1.2.0",
-        "remark-normalize-headings": "^2",
-        "remark-preset-lint-consistent": "^4.0",
-        "remark-preset-lint-recommended": "^5.0"
+        "remark-normalize-headings": "^3",
+        "remark-preset-lint-consistent": "^5.0",
+        "remark-preset-lint-recommended": "^6.0"
     },
     "scripts": {
         "?docs:build": "Generate documentation as static Web site",


### PR DESCRIPTION
- Do not publish docs via GitHub action
- Instead, use Jenkins Pipeline to publish them
- Bump version of Hadolint
- Bump version of Remark
- Use Ubuntu 20.10 as base image for CI because of compatibility reasons
- Remove workaround for MkDocs minify plugin