### PR TITLE
Fix Dockerfile-ci

### DIFF
--- a/Dockerfile-ci
+++ b/Dockerfile-ci
@@ -1,5 +1,5 @@
 # FROM ubuntu:rolling
-FROM ubuntu:20.10
+FROM ubuntu:21.10
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/docs/user/usecases/locations.md
+++ b/docs/user/usecases/locations.md
@@ -31,7 +31,7 @@ Beside these classes there is a category for each object where you can store the
 
 After documenting all of the needed objects, you are able to assign them to the objects from the corresponding classes. This can be done within the category "location" to build up the location tree.
 
-As soon as the assignment of these objects is done, you can change the finder's view to "location" and see a cascadic view of your locations. This can be opened until you reach your desired object within this tree.
+As soon as the assignment of these objects is done, you can change the finder's view to "location" and see a cascade view of your locations. This can be opened until you reach your desired object within this tree.
 
 An example for a location path within your location tree looks like this:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -93,7 +93,7 @@ nav:
       - Reporting: user/reporting.md
       # - Imports:
       #     - CSV: user/imports/csv.md
-      - Use cases: 
+      - Use cases 
           - Locations: user/usecases/locations.md
   - Admin guide:
       - Users, groups and roles: admin/users-groups-roles.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -93,7 +93,7 @@ nav:
       - Reporting: user/reporting.md
       # - Imports:
       #     - CSV: user/imports/csv.md
-      - Use cases 
+  - Use cases: 
           - Locations: user/usecases/locations.md
   - Admin guide:
       - Users, groups and roles: admin/users-groups-roles.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -94,7 +94,7 @@ nav:
       # - Imports:
       #     - CSV: user/imports/csv.md
   - Use cases:
-          - Locations: user/usecases/locations.md
+      - Locations: user/usecases/locations.md
   - Admin guide:
       - Users, groups and roles: admin/users-groups-roles.md
       - Rights and permissions: admin/rights-and-permissions.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -93,7 +93,7 @@ nav:
       - Reporting: user/reporting.md
       # - Imports:
       #     - CSV: user/imports/csv.md
-  - Use cases: 
+  - Use cases:
           - Locations: user/usecases/locations.md
   - Admin guide:
       - Users, groups and roles: admin/users-groups-roles.md


### PR DESCRIPTION
Changed the Ubuntu version for the CI dockerfile

The used Ubuntu version 20.10 is not supported anymore therefore some packages are missing. The version is changed to 21.10.

### Changed

-   Dockerfile-ci: changed the used Ubuntu version from 20.10 to 21.10

### Fixed

-   Spelling errors in locations.md fixed
-   Trailing-spaces and wrong indentations in mkdocs.yml fixed

### Conditions

By sending this pull request I have read and accept the following conditions:

-   [X] I have read the [code of conduct](../CODE_OF_CONDUCT.md) and accept it.
-   [X] I have read the [contributing guidelines](../CONTRIBUTING.md) and accept them.
-   [X] I have read the [writing guidelines](../GUIDELINES.md) and accept them.
-   [X] I accept that my contribution will be licensed under a [CC BY-SA 4.0 License](../LICENSE).
