### PR TITLE
Update toolchain/2022/20

### DIFF
--- a/Dockerfile-ci
+++ b/Dockerfile-ci
@@ -97,7 +97,6 @@ RUN pip3 install --upgrade --no-cache-dir \
         wheel \
     ; \
     apt-get remove -y \
-        python3-cryptography \
         python3-pip \
         python3-setuptools \
         python3-wheel \

--- a/Dockerfile-ci
+++ b/Dockerfile-ci
@@ -1,5 +1,4 @@
-# FROM ubuntu:rolling
-FROM ubuntu:21.10
+FROM ubuntu:rolling
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -49,7 +48,7 @@ RUN curl -fsSL https://raw.githubusercontent.com/tj/n/master/bin/n \
     npm install -g npm@latest
 
 # hadolint:
-ARG HADOLINT_VERSION=2.8.0
+ARG HADOLINT_VERSION=2.10.0
 RUN curl -fsSL \
         "https://github.com/hadolint/hadolint/releases/download/v${HADOLINT_VERSION}/hadolint-Linux-x86_64" \
         -o /usr/local/bin/hadolint; \
@@ -75,7 +74,7 @@ RUN curl -fsSL \
     rm -rf /var/lib/apt/lists/*
 
 # Docker Compose:
-ARG DOCKER_COMPOSE_VERSION=2.2.2
+ARG DOCKER_COMPOSE_VERSION=2.5.0
 RUN curl -fsSL \
         "https://github.com/docker/compose/releases/download/v${DOCKER_COMPOSE_VERSION}/docker-compose-linux-x86_64" \
         -o /usr/libexec/docker/cli-plugins/docker-compose; \
@@ -98,6 +97,7 @@ RUN pip3 install --upgrade --no-cache-dir \
         wheel \
     ; \
     apt-get remove -y \
+        python3-cryptography \
         python3-pip \
         python3-setuptools \
         python3-wheel \

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "devDependencies": {
         "alex": "^10",
         "cloc": "^2.8.0",
-        "husky": "^7",
+        "husky": "^8",
         "jscpd": "^3.3.25",
         "jsonlint": "^1.6.3",
         "markdown-spellcheck": "git+https://github.com/lukeapage/node-markdown-spellcheck.git",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,12 @@
+cryptography
+Jinja2
+Markdown
 mkdocs
 mkdocs-git-revision-date-localized-plugin
 mkdocs-material
 mkdocs-minify-plugin
 mkdocs-rss-plugin
 pygments
+pyOpenSSL
 wheel
 yamllint


### PR DESCRIPTION
Bump versions of dependencies:
- Ubuntu
- Hadolint
- Docker Compose
- Python library cryptography
- Python library pyOpenSSL
- Python library Jinja2
- Python library Markdown
- Husky