### PR TITLE
Revert "Update markdown requirement from ~=3.3.7 to ~=3.4.1"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 cryptography ~= 38.0.4
 cyclonedx-bom == 3.7.2
 Jinja2 ~= 3.1.2
-Markdown ~= 3.3.7
+Markdown ~= 3.4
 mkdocs == 1.4.2
 mkdocs-git-revision-date-localized-plugin ~= 1.1.0
 mkdocs-macros-plugin ~= 0.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 cryptography ~= 38.0.4
 cyclonedx-bom == 3.7.2
 Jinja2 ~= 3.1.2
-Markdown ~= 3.4.1
+Markdown ~= 3.3.7
 mkdocs == 1.4.2
 mkdocs-git-revision-date-localized-plugin ~= 1.1.0
 mkdocs-macros-plugin ~= 0.7.0


### PR DESCRIPTION
Reverts i-doit/docs#71
mkdocs not support markdown >=3.4